### PR TITLE
Fixed My Notes

### DIFF
--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -93,7 +93,7 @@ class mybooks_notes(delegate.page):
         i = web.input(page=1)
         mb = MyBooksTemplate(username, key='notes')
         if mb.is_my_page:
-            docs = PatronBooknotes(mb.user).get_notes(page=i.page)
+            docs = PatronBooknotes(mb.user).get_notes(page=int(i.page))
             template = render['account/notes'](
                 docs, mb.user, mb.counts['notes'], page=i.page
             )


### PR DESCRIPTION


<!-- What issue does this PR close? -->
Closes #8771

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Going to page 2 of notes breaks because the page is a string instead of an int so added one line to convert string to int.

### Technical
<!-- What should be noted about the implementation? -->
 
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to link:http://localhost:8080/people/openlibrary/books/notes?page=2&debug=true and check if we get type error.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before:
![Screenshot from 2024-01-29 15-22-06](https://github.com/Ayush1404/openlibrary/assets/59080746/36dbd534-ec25-4b44-9df0-c4c236a32e0e)
After:
![Screenshot from 2024-01-29 15-22-38](https://github.com/Ayush1404/openlibrary/assets/59080746/a8b98d98-a73e-419d-9702-a1f42658ba64)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
